### PR TITLE
Kind request to deprecate package in favor of the official version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-Bootstap material design for Meteor
+Bootstrap Material Design now integrates natively with Meteor. Please use
 
-http://fezvrasta.github.io/bootstrap-material-design/ packaged for meteor.
+https://atmospherejs.com/fezvrasta/bootstrap-material-design (full package)
+
+or 
+
+https://atmospherejs.com/fezvrasta/bootstrap-material-design-noglyph (no Glyphicons - useful if you want to use another icon set, e.g. Font Awesome).


### PR DESCRIPTION
Hi @djedi23,

I've worked with @FezVrasta to provide a native Meteor integration for Material Desgin.

Would you like to support this effort? All you need to do is hide this package from Atmosphere, so searches will show the official package:

```
meteor admin set-unmigrated djedi:bootstrap-material-design
```

The package will still be installable by apps and other packages that depend on it; it will just be hidden from Atmosphere searches.

Thanks,
Dan
